### PR TITLE
Add auto_docking example script & dock launch arg

### DIFF
--- a/interbotix_ros_xslocobots/examples/python_demos/auto_docking.py
+++ b/interbotix_ros_xslocobots/examples/python_demos/auto_docking.py
@@ -2,20 +2,23 @@ import math
 from interbotix_xs_modules.locobot import InterbotixLocobotXS
 
 # This script sends the Locobot to its docking station to charge
-#
-# To get started, open a terminal and type...
-# 'roslaunch interbotix_xslocobot_control xslocobot_python.launch robot_model:=locobot_MODEL use_base:=true dock:=true'
-# Then change to this directory and type 'python auto_docking.py'
+#   For best performance, robot should be under 1m in front of the dock
+#   Note that this script should only be run on robots with smaller or no arms
+#       - locobot_base
+#       - locobot_px100
 
-# Change this value to your locobot model
+# Update this value with your model
 MODEL = "locobot_px100"
+
+# To get started, open a terminal on the robot and type...
+# 'roslaunch interbotix_xslocobot_control xslocobot_python.launch robot_model:=MODEL use_base:=true dock:=true'
+#                                                                                ^ update MODEL
+# Then open a new terminal in this directory and type 'python auto_docking.py'
+
 
 def main(): 
     locobot = InterbotixLocobotXS(robot_model=MODEL)
-    if locobot.base.auto_dock():
-        print("Docking Successful.")
-    else:
-        print("Docking Unsuccessful.")
+    locobot.base.auto_dock()
 
 
 if __name__ == "__main__":

--- a/interbotix_ros_xslocobots/examples/python_demos/auto_docking.py
+++ b/interbotix_ros_xslocobots/examples/python_demos/auto_docking.py
@@ -1,0 +1,15 @@
+import math
+from interbotix_xs_modules.locobot import InterbotixLocobotXS
+
+# This script sends the Locobot to its docking station to charge
+#
+# To get started, open a terminal and type...
+# 'roslaunch interbotix_xslocobot_control xslocobot_python.launch robot_model:=locobot_wx250s show_lidar:=true'
+# Then change to this directory and type 'python auto_docking.py'
+
+def main(): 
+    locobot = InterbotixLocobotXS(robot_model="locobot_wx250s")
+    locobot.base.auto_dock()
+
+if __name__ == "__main__":
+    main()

--- a/interbotix_ros_xslocobots/examples/python_demos/auto_docking.py
+++ b/interbotix_ros_xslocobots/examples/python_demos/auto_docking.py
@@ -4,12 +4,19 @@ from interbotix_xs_modules.locobot import InterbotixLocobotXS
 # This script sends the Locobot to its docking station to charge
 #
 # To get started, open a terminal and type...
-# 'roslaunch interbotix_xslocobot_control xslocobot_python.launch robot_model:=locobot_wx250s show_lidar:=true'
+# 'roslaunch interbotix_xslocobot_control xslocobot_python.launch robot_model:=locobot_MODEL use_base:=true dock:=true'
 # Then change to this directory and type 'python auto_docking.py'
 
+# Change this value to your locobot model
+MODEL = "locobot_px100"
+
 def main(): 
-    locobot = InterbotixLocobotXS(robot_model="locobot_wx250s")
-    locobot.base.auto_dock()
+    locobot = InterbotixLocobotXS(robot_model=MODEL)
+    if locobot.base.auto_dock():
+        print("Docking Successful.")
+    else:
+        print("Docking Unsuccessful.")
+
 
 if __name__ == "__main__":
     main()

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_control/launch/xslocobot_control.launch
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_control/launch/xslocobot_control.launch
@@ -8,6 +8,7 @@
   <arg name="use_rviz"                          default="false"/>
   <arg name="rviz_frame"                        default="$(arg robot_name)/base_footprint"/>
   <arg name="use_base"                          default="false"/>
+  <arg name="dock"                              default="false"/>
   <arg name="use_lidar"                         default="false"/>
   <arg name="show_lidar"                        default="$(arg use_lidar)"/>
   <arg name="use_camera"                        default="false"/>
@@ -81,6 +82,14 @@
       pkg="diagnostic_aggregator"
       type="aggregator_node">
       <rosparam command="load"                      file="$(find kobuki_node)/param/diagnostics.yaml" />
+    </node>
+
+    <node if="$(arg dock)"
+      pkg="nodelet" 
+      type="nodelet" 
+      name="dock_drive" 
+      args="load kobuki_auto_docking/AutoDockingNodelet mobile_base_nodelet_manager">
+      <rosparam command="load"                      file="$(find kobuki_auto_docking)/param/auto_docking.yaml" />
     </node>
   </group>
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_control/launch/xslocobot_control.launch
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_control/launch/xslocobot_control.launch
@@ -90,6 +90,11 @@
       name="dock_drive" 
       args="load kobuki_auto_docking/AutoDockingNodelet mobile_base_nodelet_manager">
       <rosparam command="load"                      file="$(find kobuki_auto_docking)/param/auto_docking.yaml" />
+      <remap from="dock_drive/odom"                 to="mobile_base/odom" />
+      <remap from="dock_drive/core"                 to="mobile_base/sensors/core" />
+      <remap from="dock_drive/dock_ir"              to="mobile_base/sensors/dock_ir" />
+      <remap from="dock_drive/motor_power"          to="mobile_base/commands/motor_power" />
+      <remap from="dock_drive/velocity"             to="mobile_base/commands/velocity" />
     </node>
   </group>
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_control/launch/xslocobot_python.launch
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_control/launch/xslocobot_python.launch
@@ -16,6 +16,7 @@
   <arg name="use_rviz"                          default="false"/>
   <arg name="rviz_frame"                        default="$(arg robot_name)/base_footprint"/>
   <arg name="use_base"                          default="$(arg use_nav)"/>
+  <arg name="dock"                              default="true"/>
   <arg name="use_lidar"                         default="false"/>
   <arg name="show_lidar"                        default="$(arg use_lidar)"/>
   <arg name="use_camera"                        default="$(eval arg('use_nav') or arg('use_perception'))"/>
@@ -77,6 +78,7 @@
     <arg name="use_camera"                        value="$(arg use_camera)"/>
     <arg name="use_lidar"                         value="$(arg use_lidar)"/>
     <arg name="use_base"                          value="$(arg use_base)"/>
+    <arg name="dock"                              value="$(arg dock)"/>
     <arg name="filters"                           value="$(arg filters)"/>
     <arg name="align_depth"                       value="$(arg align_depth)"/>
     <arg name="color_fps"                         value="$(arg color_fps)"/>

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_control/launch/xslocobot_python.launch
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_control/launch/xslocobot_python.launch
@@ -16,7 +16,7 @@
   <arg name="use_rviz"                          default="false"/>
   <arg name="rviz_frame"                        default="$(arg robot_name)/base_footprint"/>
   <arg name="use_base"                          default="$(arg use_nav)"/>
-  <arg name="dock"                              default="true"/>
+  <arg name="dock"                              default="false"/>
   <arg name="use_lidar"                         default="false"/>
   <arg name="show_lidar"                        default="$(arg use_lidar)"/>
   <arg name="use_camera"                        default="$(eval arg('use_nav') or arg('use_perception'))"/>


### PR DESCRIPTION
# Summary
Added `auto_docking.py` script to Python examples. This script demonstrates the automatic docking feature of the LoCoBot's Kobuki base. Added `dock` arg to `xslocobot_control` and `xslocobot_python` launch files that, if set to true, loads the `kobuki_auto_docking/AutoDockingNodelet` nodelet and remaps relevant topics.

This was done to prepare for higher-level autonomous navigation features in future releases.