### PR TITLE
[xslocobot_descriptions] Add missing kobuki robot param node

### DIFF
--- a/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/kobuki_version/locobot_kobuki.urdf.xacro
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/kobuki_version/locobot_kobuki.urdf.xacro
@@ -530,12 +530,12 @@
     <!-- Gazebo ROS Control -->
     <xacro:if value="${hardware_type == 'gz_classic'}">
       <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
-          <ros>
-            <namespace>/$(arg robot_name)</namespace>
-          </ros>
-          <robot_param>robot_description</robot_param>
-          <robot_param_node>robot_state_publisher</robot_param_node>
-          <parameters> $(find interbotix_xslocobot_sim)/config/kobuki_version/$(arg robot_model)_controllers.yaml </parameters>
+        <ros>
+          <namespace>/$(arg robot_name)</namespace>
+        </ros>
+        <robot_param>robot_description</robot_param>
+        <robot_param_node>robot_state_publisher</robot_param_node>
+        <parameters> $(find interbotix_xslocobot_sim)/config/kobuki_version/$(arg robot_model)_controllers.yaml </parameters>
       </plugin>
     </xacro:if>
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/kobuki_version/locobot_kobuki.urdf.xacro
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/kobuki_version/locobot_kobuki.urdf.xacro
@@ -530,7 +530,12 @@
     <!-- Gazebo ROS Control -->
     <xacro:if value="${hardware_type == 'gz_classic'}">
       <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
-        <parameters> $(find interbotix_xslocobot_sim)/config/kobuki_version/$(arg robot_model)_controllers.yaml </parameters>
+          <ros>
+            <namespace>/$(arg robot_name)</namespace>
+          </ros>
+          <robot_param>robot_description</robot_param>
+          <robot_param_node>robot_state_publisher</robot_param_node>
+          <parameters> $(find interbotix_xslocobot_sim)/config/kobuki_version/$(arg robot_model)_controllers.yaml </parameters>
       </plugin>
     </xacro:if>
 


### PR DESCRIPTION
Issue:
Gazebo error when launching simulation for kobuki version
`[gazebo_ros2_control]: robot_state_publisher service not available, waiting again...`

Fix:
Added 5 lines in locobot_kobuki.urdf.xacro following example from locobot_create3.xacro line 143-145