### PR TITLE
[xslocobot_sim] fix double namespace issue

### DIFF
--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_base_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_base_controllers.yaml
@@ -35,8 +35,8 @@ locobot:
       right_wheel_radius_multiplier: 1.0
 
       publish_rate: 62.0
-      odom_frame_id: locobot/odom
-      base_frame_id: locobot/base_footprint
+      odom_frame_id: odom
+      base_frame_id: base_footprint
       pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
       twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_px100_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_px100_controllers.yaml
@@ -75,8 +75,8 @@ locobot:
       right_wheel_radius_multiplier: 1.0
 
       publish_rate: 62.0
-      odom_frame_id: locobot/odom
-      base_frame_id: locobot/base_footprint
+      odom_frame_id: odom
+      base_frame_id: base_footprint
       pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
       twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx200_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx200_controllers.yaml
@@ -77,8 +77,8 @@ locobot:
       right_wheel_radius_multiplier: 1.0
 
       publish_rate: 62.0
-      odom_frame_id: locobot/odom
-      base_frame_id: locobot/base_footprint
+      odom_frame_id: odom
+      base_frame_id: base_footprint
       pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
       twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx250s_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx250s_controllers.yaml
@@ -79,8 +79,8 @@ locobot:
       right_wheel_radius_multiplier: 1.0
 
       publish_rate: 62.0
-      odom_frame_id: locobot/odom
-      base_frame_id: locobot/base_footprint
+      odom_frame_id: odom
+      base_frame_id: base_footprint
       pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
       twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_base_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_base_controllers.yaml
@@ -35,8 +35,8 @@ locobot:
       right_wheel_radius_multiplier: 1.0
 
       publish_rate: 62.0
-      odom_frame_id: locobot/odom
-      base_frame_id: locobot/base_footprint
+      odom_frame_id: odom
+      base_frame_id: base_footprint
       pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
       twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_px100_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_px100_controllers.yaml
@@ -75,8 +75,8 @@ locobot:
       right_wheel_radius_multiplier: 1.0
 
       publish_rate: 62.0
-      odom_frame_id: locobot/odom
-      base_frame_id: locobot/base_footprint
+      odom_frame_id: odom
+      base_frame_id: base_footprint
       pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
       twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx200_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx200_controllers.yaml
@@ -77,8 +77,8 @@ locobot:
       right_wheel_radius_multiplier: 1.0
 
       publish_rate: 62.0
-      odom_frame_id: locobot/odom
-      base_frame_id: locobot/base_footprint
+      odom_frame_id: odom
+      base_frame_id: base_footprint
       pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
       twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx250s_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx250s_controllers.yaml
@@ -79,8 +79,8 @@ locobot:
       right_wheel_radius_multiplier: 1.0
 
       publish_rate: 62.0
-      odom_frame_id: locobot/odom
-      base_frame_id: locobot/base_footprint
+      odom_frame_id: odom
+      base_frame_id: base_footprint
       pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
       twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 


### PR DESCRIPTION
Double namespace issue when launching the simulator:

![image](https://user-images.githubusercontent.com/32376039/217950320-48058e17-5570-45bf-ac11-69619312829b.png)

A quick fix:
removing the robot namespace _'locobot/'_ from the _frame_ids_ of the config file, because _gazebo_ros2_control_ already appends the namespace to the frames automatically. 

 Applied to both create3 and kobuki versions.