### PR TITLE
Feature: Add slam_toolbox option for navigation2

### DIFF
--- a/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/lidar.urdf.xacro
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/lidar.urdf.xacro
@@ -136,7 +136,7 @@
         </ray>
         <plugin name="gazebo_ros_head_rplidar_controller" filename="libgazebo_ros_ray_sensor.so">
           <ros>
-            <remapping>~/out:=scan</remapping>
+            <remapping>~/out:=${robot_name}/scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>${robot_name}/laser_frame_link</frame_name>

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/nav2_params.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/nav2_params.yaml
@@ -443,7 +443,7 @@ local_costmap:
       # Frequency to publish costmap to topic. (default 1.0)
       publish_frequency: 2.0
 
-      # Reference frame. (default: map)
+      # Reference frame. (default: odom)
       global_frame: locobot/odom
 
       # Robot base frame. (default: base_link)
@@ -453,10 +453,10 @@ local_costmap:
       rolling_window: True
 
       # Height of costmap (m). (default: 5)
-      width: 3
+      width: 5
 
       # Width of costmap (m). (default: 5)
-      height: 3
+      height: 5
 
       # Resolution of 1 pixel of the costmap, in meters. (default: 0.1)
       resolution: 0.05
@@ -581,16 +581,22 @@ global_costmap:
       map_topic: map
 
       # X origin of the costmap relative to width (m). (default: 0.0)
-      origin_x: 10.0
+      origin_x: -10.0
 
       # Y origin of the costmap relative to height (m). (default: 0.0)
-      origin_y: 10.0
+      origin_y: -10.0
 
       # Frequency to publish costmap to topic. (default 1.0)
       publish_frequency: 1.0
 
+      # Height of costmap (m). (default: 5)
+      width: 20
+
+      # Width of costmap (m). (default: 5)
+      height: 20
+
       # Resolution of 1 pixel of the costmap, in meters. (default: 0.1)
-      resolution: 0.05
+      resolution: 0.1
 
       # Robot base frame. (default: base_link)
       robot_base_frame: locobot/base_link

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/nav2_params.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/nav2_params.yaml
@@ -787,7 +787,7 @@ planner_server:
 # Note: the wait recovery behavior has no parameters, the duration to wait is given in the action
 # request. Note: pre-Rolling/Humble this was the Recovery server, not behavior server. Launch
 # files, behaviors and tests were all renamed.
-recoveries_server:
+behavior_server:
   ros__parameters:
     # https://navigation.ros.org/configuration/packages/configuring-behavior-server.html?highlight=recoveries_server
 
@@ -815,13 +815,13 @@ recoveries_server:
     recovery_plugins: ["spin", "backup", "wait"]
 
     spin:
-      plugin: "nav2_recoveries/Spin"
+      plugin: "nav2_behaviors/Spin"
 
     backup:
-      plugin: "nav2_recoveries/BackUp"
+      plugin: "nav2_behaviors/BackUp"
 
     wait:
-      plugin: "nav2_recoveries/Wait"
+      plugin: "nav2_behaviors/Wait"
 
     # Time to look ahead for collisions (s). (default: 2.0)
     simulate_ahead_time: 2.0

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_localization.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_localization.yaml
@@ -54,7 +54,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
-    max_laser_range: 20.0 #for rastering images
+    max_laser_range: 16.0 #for rastering images
     minimum_time_interval: 0.5
     transform_timeout: 0.2
     tf_buffer_duration: 30.

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_localization.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_localization.yaml
@@ -1,0 +1,100 @@
+slam_toolbox:
+  ros__parameters:
+    # Solver Params
+
+    # The type of nonlinear solver to utilize for karto's scan solver. Options:
+    # `solver_plugins::CeresSolver`, `solver_plugins::SpaSolver`, `solver_plugins::G2oSolver`.
+    # Default: `solver_plugins::CeresSolver`.
+    solver_plugin: solver_plugins::CeresSolver
+
+    # The linear solver for Ceres to use. Options: `SPARSE_NORMAL_CHOLESKY`, `SPARSE_SCHUR`,
+    # `ITERATIVE_SCHUR`, `CGNR`. Defaults to `SPARSE_NORMAL_CHOLESKY`.
+    ceres_linear_solver: SPARSE_NORMAL_CHOLESKY
+
+    # The preconditioner to use with that solver. Options: `JACOBI`, `IDENTITY` (none),
+    # `SCHUR_JACOBI`. Defaults to `JACOBI`.
+    ceres_preconditioner: SCHUR_JACOBI
+
+    # The trust region strategy. Line search strategies are not exposed because they perform
+    # poorly for this use. Options: `LEVENBERG_MARQUARDT`, `DOGLEG`. Default:
+    # `LEVENBERG_MARQUARDT`.
+    ceres_trust_strategy: LEVENBERG_MARQUARDT
+
+    # The dogleg strategy to use if the trust strategy is `DOGLEG`. Options: `TRADITIONAL_DOGLEG`,
+    # `SUBSPACE_DOGLEG`. Default: `TRADITIONAL_DOGLEG`
+    ceres_dogleg_type: TRADITIONAL_DOGLEG
+
+    # The type of loss function to reject outlier measurements. None is equatable to a squared
+    # loss. Options: `None`, `HuberLoss`, `CauchyLoss`. Default: `None`.
+    ceres_loss_function: None
+
+    # "mapping" or "localization" mode for performance optimizations in the Ceres problem creation
+    mode: localization
+
+    # Toolbox Params
+
+    # Odometry frame
+    odom_frame: locobot/odom
+
+    # Map frame
+    map_frame: map
+
+    # Base frame
+    base_frame: locobot/base_footprint
+
+    # scan topic, *absolute* path, ei `/scan` not `scan`
+    scan_topic: /locobot/scan
+
+    # if you'd like to start localizing on bringup in a map and pose
+    #map_file_name: map_file
+    #map_start_pose: [5.0, 1.0, 0.0]
+
+    debug_logging: false
+    throttle_scans: 1
+    transform_publish_period: 0.02 #if 0 never publishes odometry
+    map_update_interval: 5.0
+    resolution: 0.05
+    max_laser_range: 20.0 #for rastering images
+    minimum_time_interval: 0.5
+    transform_timeout: 0.2
+    tf_buffer_duration: 30.
+    stack_size_to_use: 40000000 # program needs a larger stack size to serialize large maps
+
+    # Matcher Params
+
+    # General Parameters
+    use_scan_matching: true
+    use_scan_barycenter: true
+    minimum_travel_distance: 0.5
+    minimum_travel_heading: 0.5
+    scan_buffer_size: 3
+    scan_buffer_maximum_scan_distance: 10.0
+    link_match_minimum_response_fine: 0.1
+    link_scan_maximum_distance: 1.5
+    do_loop_closing: true
+    loop_match_minimum_chain_size: 3
+    loop_match_maximum_variance_coarse: 3.0
+    loop_match_minimum_response_coarse: 0.35
+    loop_match_minimum_response_fine: 0.45
+
+    # Correlation Parameters - Correlation Parameters
+    correlation_search_space_dimension: 0.5
+    correlation_search_space_resolution: 0.01
+    correlation_search_space_smear_deviation: 0.1
+
+    # Correlation Parameters - Loop Closure Parameters
+    loop_search_space_dimension: 8.0
+    loop_search_space_resolution: 0.05
+    loop_search_space_smear_deviation: 0.03
+    loop_search_maximum_distance: 3.0
+
+    # Scan Matcher Parameters
+    distance_variance_penalty: 0.5
+    angle_variance_penalty: 1.0
+
+    fine_search_angle_offset: 0.00349
+    coarse_search_angle_offset: 0.349
+    coarse_angle_resolution: 0.0349
+    minimum_angle_penalty: 0.9
+    minimum_distance_penalty: 0.5
+    use_response_expansion: true

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_online_async.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_online_async.yaml
@@ -59,7 +59,7 @@ slam_toolbox:
         transform_publish_period: 0.02 #if 0 never publishes odometry
         map_update_interval: 5.0
         resolution: 0.05
-        max_laser_range: 20.0 #for rastering images
+        max_laser_range: 16.0 #for rastering images
         minimum_time_interval: 0.5
         transform_timeout: 0.2
         tf_buffer_duration: 30.

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_online_async.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_online_async.yaml
@@ -1,0 +1,104 @@
+slam_toolbox:
+    ros__parameters:
+        # Solver Params
+
+        test_param: test
+
+        # The type of nonlinear solver to utilize for karto's scan solver. Options:
+        # `solver_plugins::CeresSolver`, `solver_plugins::SpaSolver`, `solver_plugins::G2oSolver`.
+        # Default: `solver_plugins::CeresSolver`.
+        solver_plugin: solver_plugins::CeresSolver
+
+        # The linear solver for Ceres to use. Options: `SPARSE_NORMAL_CHOLESKY`, `SPARSE_SCHUR`,
+        # `ITERATIVE_SCHUR`, `CGNR`. Defaults to `SPARSE_NORMAL_CHOLESKY`.
+        ceres_linear_solver: SPARSE_NORMAL_CHOLESKY
+
+        # The preconditioner to use with that solver. Options: `JACOBI`, `IDENTITY` (none),
+        # `SCHUR_JACOBI`. Defaults to `JACOBI`.
+        ceres_preconditioner: SCHUR_JACOBI
+
+        # The trust region strategy. Line search strategies are not exposed because they perform
+        # poorly for this use. Options: `LEVENBERG_MARQUARDT`, `DOGLEG`. Default:
+        # `LEVENBERG_MARQUARDT`.
+        ceres_trust_strategy: LEVENBERG_MARQUARDT
+
+        # The dogleg strategy to use if the trust strategy is `DOGLEG`. Options: `TRADITIONAL_DOGLEG`,
+        # `SUBSPACE_DOGLEG`. Default: `TRADITIONAL_DOGLEG`
+        ceres_dogleg_type: TRADITIONAL_DOGLEG
+
+        # The type of loss function to reject outlier measurements. None is equatable to a squared
+        # loss. Options: `None`, `HuberLoss`, `CauchyLoss`. Default: `None`.
+        ceres_loss_function: None
+
+        # "mapping" or "localization" mode for performance optimizations in the Ceres problem creation
+        mode: mapping
+
+        # Toolbox Params
+
+        # Odometry frame
+        odom_frame: locobot/odom
+
+        # Map frame
+        map_frame: map
+
+        # Base frame
+        base_frame: locobot/base_footprint
+
+        # scan topic, *absolute* path, ei `/scan` not `scan`
+        scan_topic: /locobot/scan
+
+        # if you'd like to immediately start continuing a map at a given pose
+        # or at the dock, but they are mutually exclusive, if pose is given
+        # will use pose
+        #map_file_name: map_file
+        # map_start_pose: [0.0, 0.0, 0.0]
+        #map_start_at_dock: true
+
+        debug_logging: false
+        throttle_scans: 1
+        transform_publish_period: 0.02 #if 0 never publishes odometry
+        map_update_interval: 5.0
+        resolution: 0.05
+        max_laser_range: 20.0 #for rastering images
+        minimum_time_interval: 0.5
+        transform_timeout: 0.2
+        tf_buffer_duration: 30.
+        stack_size_to_use: 40000000 #// program needs a larger stack size to serialize large maps
+        enable_interactive_mode: true
+
+        # General Parameters
+        use_scan_matching: true
+        use_scan_barycenter: true
+        minimum_travel_distance: 0.5
+        minimum_travel_heading: 0.5
+        scan_buffer_size: 10
+        scan_buffer_maximum_scan_distance: 10.0
+        link_match_minimum_response_fine: 0.1
+        link_scan_maximum_distance: 1.5
+        loop_search_maximum_distance: 3.0
+        do_loop_closing: true
+        loop_match_minimum_chain_size: 10
+        loop_match_maximum_variance_coarse: 3.0
+        loop_match_minimum_response_coarse: 0.35
+        loop_match_minimum_response_fine: 0.45
+
+        # Correlation Parameters - Correlation Parameters
+        correlation_search_space_dimension: 0.5
+        correlation_search_space_resolution: 0.01
+        correlation_search_space_smear_deviation: 0.1
+
+        # Correlation Parameters - Loop Closure Parameters
+        loop_search_space_dimension: 8.0
+        loop_search_space_resolution: 0.05
+        loop_search_space_smear_deviation: 0.03
+
+        # Scan Matcher Parameters
+        distance_variance_penalty: 0.5
+        angle_variance_penalty: 1.0
+
+        fine_search_angle_offset: 0.00349
+        coarse_search_angle_offset: 0.349
+        coarse_angle_resolution: 0.0349
+        minimum_angle_penalty: 0.9
+        minimum_distance_penalty: 0.5
+        use_response_expansion: true

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_online_sync.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_online_sync.yaml
@@ -1,0 +1,102 @@
+slam_toolbox:
+    ros__parameters:
+        # Solver Params
+
+        # The type of nonlinear solver to utilize for karto's scan solver. Options:
+        # `solver_plugins::CeresSolver`, `solver_plugins::SpaSolver`, `solver_plugins::G2oSolver`.
+        # Default: `solver_plugins::CeresSolver`.
+        solver_plugin: solver_plugins::CeresSolver
+
+        # The linear solver for Ceres to use. Options: `SPARSE_NORMAL_CHOLESKY`, `SPARSE_SCHUR`,
+        # `ITERATIVE_SCHUR`, `CGNR`. Defaults to `SPARSE_NORMAL_CHOLESKY`.
+        ceres_linear_solver: SPARSE_NORMAL_CHOLESKY
+
+        # The preconditioner to use with that solver. Options: `JACOBI`, `IDENTITY` (none),
+        # `SCHUR_JACOBI`. Defaults to `JACOBI`.
+        ceres_preconditioner: SCHUR_JACOBI
+
+        # The trust region strategy. Line search strategies are not exposed because they perform
+        # poorly for this use. Options: `LEVENBERG_MARQUARDT`, `DOGLEG`. Default:
+        # `LEVENBERG_MARQUARDT`.
+        ceres_trust_strategy: LEVENBERG_MARQUARDT
+
+        # The dogleg strategy to use if the trust strategy is `DOGLEG`. Options: `TRADITIONAL_DOGLEG`,
+        # `SUBSPACE_DOGLEG`. Default: `TRADITIONAL_DOGLEG`
+        ceres_dogleg_type: TRADITIONAL_DOGLEG
+
+        # The type of loss function to reject outlier measurements. None is equatable to a squared
+        # loss. Options: `None`, `HuberLoss`, `CauchyLoss`. Default: `None`.
+        ceres_loss_function: None
+
+        # "mapping" or "localization" mode for performance optimizations in the Ceres problem creation
+        mode: mapping
+
+        # Toolbox Params
+
+        # Odometry frame
+        odom_frame: locobot/odom
+
+        # Map frame
+        map_frame: map
+
+        # Base frame
+        base_frame: locobot/base_footprint
+
+        # scan topic, *absolute* path, ei `/scan` not `scan`
+        scan_topic: /locobot/scan
+
+        # if you'd like to immediately start continuing a map at a given pose
+        # or at the dock, but they are mutually exclusive, if pose is given
+        # will use pose
+        #map_file_name: map_file
+        # map_start_pose: [0.0, 0.0, 0.0]
+        #map_start_at_dock: true
+
+        debug_logging: false
+        throttle_scans: 1
+        transform_publish_period: 0.02 #if 0 never publishes odometry
+        map_update_interval: 5.0
+        resolution: 0.05
+        max_laser_range: 20.0 #for rastering images
+        minimum_time_interval: 0.5
+        transform_timeout: 0.2
+        tf_buffer_duration: 30.
+        stack_size_to_use: 40000000 #// program needs a larger stack size to serialize large maps
+        enable_interactive_mode: true
+
+        # General Parameters
+        use_scan_matching: true
+        use_scan_barycenter: true
+        minimum_travel_distance: 0.5
+        minimum_travel_heading: 0.5
+        scan_buffer_size: 10
+        scan_buffer_maximum_scan_distance: 10.0
+        link_match_minimum_response_fine: 0.1
+        link_scan_maximum_distance: 1.5
+        loop_search_maximum_distance: 3.0
+        do_loop_closing: true
+        loop_match_minimum_chain_size: 10
+        loop_match_maximum_variance_coarse: 3.0
+        loop_match_minimum_response_coarse: 0.35
+        loop_match_minimum_response_fine: 0.45
+
+        # Correlation Parameters - Correlation Parameters
+        correlation_search_space_dimension: 0.5
+        correlation_search_space_resolution: 0.01
+        correlation_search_space_smear_deviation: 0.1
+
+        # Correlation Parameters - Loop Closure Parameters
+        loop_search_space_dimension: 8.0
+        loop_search_space_resolution: 0.05
+        loop_search_space_smear_deviation: 0.03
+
+        # Scan Matcher Parameters
+        distance_variance_penalty: 0.5
+        angle_variance_penalty: 1.0
+
+        fine_search_angle_offset: 0.00349
+        coarse_search_angle_offset: 0.349
+        coarse_angle_resolution: 0.0349
+        minimum_angle_penalty: 0.9
+        minimum_distance_penalty: 0.5
+        use_response_expansion: true

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_online_sync.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/config/slam_toolbox_online_sync.yaml
@@ -57,7 +57,7 @@ slam_toolbox:
         transform_publish_period: 0.02 #if 0 never publishes odometry
         map_update_interval: 5.0
         resolution: 0.05
-        max_laser_range: 20.0 #for rastering images
+        max_laser_range: 16.0 #for rastering images
         minimum_time_interval: 0.5
         transform_timeout: 0.2
         tf_buffer_duration: 30.

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_nav2_bringup.launch.py
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_nav2_bringup.launch.py
@@ -60,7 +60,7 @@ def launch_setup(context, *args, **kwargs):
     lifecycle_nodes = [
         'controller_server',
         'planner_server',
-        'recoveries_server',
+        'behavior_server',
         'bt_navigator',
         'waypoint_follower'
     ]
@@ -104,9 +104,9 @@ def launch_setup(context, *args, **kwargs):
     )
 
     recoveries_server_node = Node(
-        package='nav2_recoveries',
-        executable='recoveries_server',
-        name='recoveries_server',
+        package='nav2_behaviors',
+        executable='behavior_server',
+        name='behavior_server',
         output='screen',
         parameters=[
             configured_params

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_nav2_bringup.launch.py
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_nav2_bringup.launch.py
@@ -31,7 +31,6 @@ This launch script borrows heavily from the original Nav2 bringup launch file:
     https://github.com/ros-planning/navigation2/blob/2de3f92c0f476de4bda21d1fc5268657b499b258/nav2_bringup/bringup/launch/bringup_launch.py
 """
 
-from multiprocessing import Condition
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
@@ -67,7 +66,6 @@ def launch_setup(context, *args, **kwargs):
     nav2_params_file_launch_arg = LaunchConfiguration('nav2_params_file')
     cmd_vel_topic_launch_arg = LaunchConfiguration('cmd_vel_topic')
     use_slam_toolbox_launch_arg = LaunchConfiguration('use_slam_toolbox')
-    slam_toolbox_mode_launch_arg = LaunchConfiguration('slam_toolbox_mode')
     map_yaml_file_launch_arg = LaunchConfiguration('map')
     # Set env var to print messages to stdout immediately
     set_logging_env_var = SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '1')
@@ -269,7 +267,6 @@ def launch_setup(context, *args, **kwargs):
         waypoint_follower_node,
         lifecycle_manager_navigation_node,
         slam_toolbox_nav2_nodes,
-
     ]
 
 def generate_launch_description():
@@ -360,7 +357,7 @@ def generate_launch_description():
             'log_level',
             default_value='info',
             choices=('debug', 'info', 'warn', 'error', 'fatal'),
-            description='log'
+            description='set the logging level of the Nav2 nodes.'
         )
     )
     declared_arguments.append(

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_slam_toolbox.launch.py
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_slam_toolbox.launch.py
@@ -1,0 +1,343 @@
+# Copyright 2022 Trossen Robotics
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from interbotix_xs_modules.xs_common import (
+    get_interbotix_xslocobot_models,
+)
+from interbotix_xs_modules.xs_launch import (
+    declare_interbotix_xslocobot_robot_description_launch_arguments,
+    determine_use_sim_time_param,
+)
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
+from launch.conditions import (
+    IfCondition,
+    LaunchConfigurationEquals,
+)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import (
+    EnvironmentVariable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+)
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def launch_setup(context, *args, **kwargs):
+    robot_model_launch_arg = LaunchConfiguration('robot_model')
+    robot_name_launch_arg = LaunchConfiguration('robot_name')
+    arm_model_launch_arg = LaunchConfiguration('arm_model')
+    xs_driver_logging_level_launch_arg = LaunchConfiguration('xs_driver_logging_level')
+    use_rviz_launch_arg = LaunchConfiguration('use_rviz')
+    slam_toolbox_params_file_launch_arg = LaunchConfiguration('slam_toolbox_params_file')
+    slam_mode_launch_arg = LaunchConfiguration('slam_mode')
+    camera_tilt_angle_launch_arg = LaunchConfiguration('camera_tilt_angle')
+    launch_driver_launch_arg = LaunchConfiguration('launch_driver')
+    hardware_type_launch_arg = LaunchConfiguration('hardware_type')
+    use_base_odom_tf_launch_arg = LaunchConfiguration('use_base_odom_tf')
+    launch_nav2_launch_arg = LaunchConfiguration('launch_nav2')
+
+    # sets use_sim_time parameter to 'true' if using gazebo hardware
+    use_sim_time_param = determine_use_sim_time_param(
+        context=context,
+        hardware_type_launch_arg=hardware_type_launch_arg
+    )
+
+    xslocobot_control_launch_include = IncludeLaunchDescription(
+        condition=IfCondition(launch_driver_launch_arg),
+        launch_description_source=PythonLaunchDescriptionSource([
+            PathJoinSubstitution([
+                FindPackageShare('interbotix_xslocobot_control'),
+                'launch',
+                'xslocobot_control.launch.py',
+            ])
+        ]),
+        launch_arguments={
+            'robot_model': robot_model_launch_arg,
+            'robot_name': robot_name_launch_arg,
+            'arm_model': arm_model_launch_arg,
+            'use_lidar': 'true',
+            'use_rviz': use_rviz_launch_arg,
+            'use_base_odom_tf': use_base_odom_tf_launch_arg,
+            'rviz_frame': 'map',
+            'use_camera': 'true',
+            'rs_camera_align_depth': 'true',
+            'use_base': 'true',
+            # 'use_dock': 'true',
+            'xs_driver_logging_level': xs_driver_logging_level_launch_arg,
+            'use_sim_time': use_sim_time_param,
+        }.items(),
+    )
+
+    camera_tilt_angle_cmd = (
+        f"ros2 topic pub --once {robot_name_launch_arg.perform(context)}/commands/joint_group "
+        "interbotix_xs_msgs/msg/JointGroupCommand "
+        f"'{{name: 'camera', cmd: [0, {camera_tilt_angle_launch_arg.perform(context)}]}}'"
+    )
+
+    camera_tilt_angle_executable = ExecuteProcess(
+        name='camera_tilt',
+        cmd=[camera_tilt_angle_cmd],
+        shell=True,
+    )
+
+    slam_toolbox_online_async_slam_node = Node(
+        condition=LaunchConfigurationEquals('slam_mode', 'online_async'),
+        package='slam_toolbox',
+        executable='async_slam_toolbox_node',
+        name='slam_toolbox',
+        parameters=[
+            slam_toolbox_params_file_launch_arg,
+            {
+                'use_sim_time': use_sim_time_param,
+            }
+        ],
+        output='screen'
+    )
+
+    slam_toolbox_localization_slam_node = Node(
+        condition=LaunchConfigurationEquals('slam_mode', 'localization'),
+        package='slam_toolbox',
+        executable='localization_slam_toolbox_node',
+        name='slam_toolbox',
+        parameters=[
+            slam_toolbox_params_file_launch_arg,
+            {
+                'use_sim_time': use_sim_time_param,
+            }
+        ],
+        output='screen'
+    )
+
+    nav2_bringup_launch_include = IncludeLaunchDescription(
+        condition=IfCondition(launch_nav2_launch_arg),
+        launch_description_source=PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare('interbotix_xslocobot_nav'),
+                'launch',
+                'xslocobot_nav2_bringup.launch.py'
+            ])
+        ),
+        launch_arguments={
+            'cmd_vel_topic': LaunchConfiguration('cmd_vel_topic'),
+            'use_sim_time': use_sim_time_param,
+            'autostart': 'true',
+            'params_file': LaunchConfiguration('nav2_params_file'),
+        }.items(),
+    )
+
+    return [
+        xslocobot_control_launch_include,
+        slam_toolbox_online_async_slam_node,
+        slam_toolbox_localization_slam_node,
+        camera_tilt_angle_executable,
+        nav2_bringup_launch_include,
+    ]
+
+
+def generate_launch_description():
+    declared_arguments = []
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'robot_model',
+            default_value=EnvironmentVariable('INTERBOTIX_XSLOCOBOT_ROBOT_MODEL'),
+            choices=get_interbotix_xslocobot_models(),
+            description=(
+              'model type of the Interbotix Locobot such as `locobot_base` or `locobot_wx250s`.'
+            )
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'robot_name',
+            default_value='locobot',
+            description='name of the robot (could be anything but defaults to `locobot`).',
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'arm_model',
+            default_value=PythonExpression([
+                '"mobile_" + "', LaunchConfiguration('robot_model'), '".split("_")[1]'
+            ]),
+            description=(
+                'the Interbotix Arm model on the locobot; this should never be set manually but '
+                'rather left to its default value.'
+            ),
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'xs_driver_logging_level',
+            default_value='INFO',
+            choices=('DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'),
+            description='set the logging level of the X-Series Driver.'
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'camera_tilt_angle',
+            default_value='0.2618',
+            description=(
+                'desired angle [rad] that the camera should be tilted when doing mapping or '
+                'localization.'
+            ),
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'use_base_odom_tf',
+            default_value='true',
+            choices=('true', 'false'),
+            description=(
+                'if `true`, the odom TF from the base will be published. This only works on the '
+                'Create 3 base.'
+            ),
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'launch_driver',
+            default_value='true',
+            choices=('true', 'false'),
+            description=(
+                '`true` if the xslocobot_control.launch.py file should be launched; set to `false`'
+                ' if you would like to run your own version of this file separately.'
+            ),
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'use_lidar',
+            default_value='true',
+            choices=('true', 'false'),
+            description='if `true`, the RPLidar node is launched.',
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'use_rviz',
+            default_value='false',
+            choices=('true', 'false'),
+            description='launches RViz if set to `true`.',
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'slam_mode',
+            default_value='online_async',
+            choices=(
+                # 'lifelong',
+                'localization',
+                # 'offline',
+                'online_async',
+                'online_sync'
+            ),
+            description=(
+                "the mode to launch the SLAM in using the slam_toolbox. Currently only "
+                "'localization', 'online_sync', and 'online_async' modes are supported."
+            ),
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'slam_toolbox_params_filename',
+            default_value=('slam_toolbox_', LaunchConfiguration('slam_mode'), '.yaml')
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'slam_toolbox_params_file',
+            default_value=PathJoinSubstitution([
+                FindPackageShare("interbotix_xslocobot_nav"),
+                'config',
+                LaunchConfiguration('slam_toolbox_params_filename'),
+            ]),
+            description='full path to the ROS 2 parameters file to use for the slam_toolbox node',
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'launch_nav2',
+            default_value='true',
+            choices=('true', 'false'),
+            description=(
+                '`true` if the Navigation2 stack should be launched; set to `false` if launching '
+                'the Nav2 stack using a different method.'
+            ),
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'nav2_params_file',
+            default_value=PathJoinSubstitution([
+                FindPackageShare('interbotix_xslocobot_nav'),
+                'config',
+                'nav2_params.yaml'
+            ]),
+            description=(
+                'full path to the ROS 2 parameters file to use when configuring the Nav2 stack.'
+            ),
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'cmd_vel_topic',
+            default_value=(LaunchConfiguration('robot_name'), '/mobile_base/cmd_vel'),
+            description="topic to remap /cmd_vel to."
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value='false',
+            choices=('true', 'false'),
+            description=(
+                'tells ROS nodes asking for time to get the Gazebo-published simulation time, '
+                'published over the ROS topic /clock; this value is automatically set to `true` if'
+                ' using Gazebo hardware.'
+            )
+        )
+    )
+    declared_arguments.extend(
+        declare_interbotix_xslocobot_robot_description_launch_arguments(
+            use_lidar='true',
+            show_gripper_bar='true',
+            show_gripper_fingers='true',
+            hardware_type='actual',
+        )
+    )
+
+    return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_slam_toolbox.launch.py
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_slam_toolbox.launch.py
@@ -68,6 +68,7 @@ def launch_setup(context, *args, **kwargs):
     hardware_type_launch_arg = LaunchConfiguration('hardware_type')
     use_base_odom_tf_launch_arg = LaunchConfiguration('use_base_odom_tf')
     launch_nav2_launch_arg = LaunchConfiguration('launch_nav2')
+    map_yaml_file_launch_arg = LaunchConfiguration('map')
 
     # sets use_sim_time parameter to 'true' if using gazebo hardware
     use_sim_time_param = determine_use_sim_time_param(
@@ -168,6 +169,9 @@ def launch_setup(context, *args, **kwargs):
             'use_sim_time': use_sim_time_param,
             'autostart': 'true',
             'params_file': LaunchConfiguration('nav2_params_file'),
+            'use_slam_toolbox': 'true',
+            'slam_toolbox_mode': slam_mode_launch_arg,
+            'map': map_yaml_file_launch_arg,
         }.items(),
     )
 
@@ -343,6 +347,13 @@ def generate_launch_description():
                 'published over the ROS topic /clock; this value is automatically set to `true` if'
                 ' using Gazebo hardware.'
             )
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'map',
+            default_value='',
+            description='Full path to map yaml file to load if using localization mode'
         )
     )
     declared_arguments.extend(

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_slam_toolbox.launch.py
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_slam_toolbox.launch.py
@@ -112,6 +112,19 @@ def launch_setup(context, *args, **kwargs):
         cmd=[camera_tilt_angle_cmd],
         shell=True,
     )
+    slam_toolbox_online_sync_slam_node = Node(
+        condition=LaunchConfigurationEquals('slam_mode', 'online_sync'),
+        package='slam_toolbox',
+        executable='sync_slam_toolbox_node',
+        name='slam_toolbox',
+        parameters=[
+            slam_toolbox_params_file_launch_arg,
+            {
+                'use_sim_time': use_sim_time_param,
+            }
+        ],
+        output='screen'
+    )
 
     slam_toolbox_online_async_slam_node = Node(
         condition=LaunchConfigurationEquals('slam_mode', 'online_async'),
@@ -160,6 +173,7 @@ def launch_setup(context, *args, **kwargs):
 
     return [
         xslocobot_control_launch_include,
+        slam_toolbox_online_sync_slam_node,
         slam_toolbox_online_async_slam_node,
         slam_toolbox_localization_slam_node,
         camera_tilt_angle_executable,

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_slam_toolbox.launch.py
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_nav/launch/xslocobot_slam_toolbox.launch.py
@@ -333,7 +333,6 @@ def generate_launch_description():
     )
     declared_arguments.extend(
         declare_interbotix_xslocobot_robot_description_launch_arguments(
-            use_lidar='true',
             show_gripper_bar='true',
             show_gripper_fingers='true',
             hardware_type='actual',

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/rviz/xslocobot_gz_classic.rviz
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/rviz/xslocobot_gz_classic.rviz
@@ -468,14 +468,94 @@ Visualization Manager:
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Best Effort
-        Value: /scan
+        Value: /locobot/scan
       Use Fixed Frame: true
       Use rainbow: true
       Value: false
+    - Class: rviz_common/Group
+      Displays:
+        - Alpha: 0.699999988079071
+          Class: rviz_default_plugins/Map
+          Color Scheme: map
+          Draw Behind: true
+          Enabled: true
+          Name: Map
+          Topic:
+            Depth: 5
+            Durability Policy: Transient Local
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /map
+          Update Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /map_updates
+          Use Timestamp: false
+          Value: true
+        - Alpha: 0.699999988079071
+          Class: rviz_default_plugins/Map
+          Color Scheme: costmap
+          Draw Behind: true
+          Enabled: true
+          Name: Global Costmap
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /global_costmap/costmap
+          Update Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /global_costmap/costmap_updates
+          Use Timestamp: false
+          Value: true
+        - Alpha: 0.699999988079071
+          Class: rviz_default_plugins/Map
+          Color Scheme: costmap
+          Draw Behind: false
+          Enabled: true
+          Name: Local Costmap
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /local_costmap/costmap
+          Update Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /local_costmap/costmap_updates
+          Use Timestamp: false
+          Value: true
+        - Alpha: 1
+          Class: rviz_default_plugins/Polygon
+          Color: 25; 255; 0
+          Enabled: true
+          Name: Robot Footprint
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /local_costmap/published_footprint
+          Value: true
+      Enabled: true
+      Name: Navigation
   Enabled: true
   Global Options:
-    Background Color: 0; 176; 240
-    Fixed Frame: base_footprint
+    Background Color: 200; 200; 200
+    Fixed Frame: map
     Frame Rate: 30
   Name: root
   Tools:


### PR DESCRIPTION
Hi,

I hope the commits and coding style fit your conventions. So in this PR, I have finished your _slam_toolbox_devel_ branch. Everything is now integrated into the humble version and running smoothly using simulation.  

**Summary**

[xslocobot_descriptions]
1. lidar.urdf.xacro
- Appended missing namespace to the LaserScan topic.

[xslocobot_nav]
1. xslocobot_slam_toolbox.launch.py
- Added sync slam toolbox node in slam_toolbox.launch.py (previously only async and localization).
- Added launch argument of use_slam_toolbox: 'true' and passing slam_mode when including the nav2_bringup launch file.
- Added launch argument of map yaml file in the case of localization mode (default=' ').
2. xslocobot_nav2_bringup.launch.py 
- Galactic to Humble migration: rename the nav2_recoveries to nav2_behaviors.
- Added _tf_remappings_ to specific nodes following https://github.com/ros-planning/navigation2/tree/humble/nav2_bringup/launch.
- Added launch argument use_slam_toolbox (default: false).
- Automatic launching of nav2_nodes such as _amcl_, _lifecycle manager slam_, _lifecycle manager localization_, _map server,_ and _map saver server_, conditioned on the slam_mode and use_slam_toolbox launch arguments.

3. nav2_params.yaml
- Galactic to Humble migration: rename the nav2_recoveries to nav2_behaviors.
- Fix costmap issues (sensor out of bounds error), change default values.
- Global costmap default: height x width 20 x 20m, resolution: 0.1.
- Place robot at the centre of the global costmap (origin -10.0, -10.0).
- Local costmap default: height x width 5 x 5m, resolution: 0.05.

[xslocobot_sim]
1. xslocobot_gz_classic.rviz
- Additional RViZ config for visualizing map and costmap topics.
- Change scan topic to /locobot/scan.

**Testing**
1. Launch simulator with RViZ
`ros2 launch interbotix_xslocobot_sim xslocobot_gz_classic.launch.py robot_model:=locobot_base robot_name:=locobot use_lidar:=true use_rviz:=true use_gazebo_gui:=true
`
2. Launch slam_toolbox
`ros2 launch interbotix_xslocobot_nav xslocobot_slam_toolbox.launch.py launch_driver:=false slam_mode:=online_sync`

![image](https://user-images.githubusercontent.com/32376039/218275016-e919bf7d-17ff-4cbc-bbcf-d4e4abaf8190.png)

3. Move the robot around by publishing the twist messages to the topic _/locobot/diffdrive_controller/cmd_vel_unstamped_ 

![image](https://user-images.githubusercontent.com/32376039/218312834-a1865357-8036-4bf8-b296-432c6e00d267.png)


