### PR TITLE
Fix Gazebo controller namespaces

### DIFF
--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_base_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_base_controllers.yaml
@@ -1,4 +1,4 @@
-locobot:
+$(var robot_name):
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_base_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_base_controllers.yaml
@@ -1,4 +1,4 @@
-$(var robot_name):
+/**:
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_px100_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_px100_controllers.yaml
@@ -1,4 +1,4 @@
-locobot:
+$(var robot_name):
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_px100_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_px100_controllers.yaml
@@ -1,4 +1,4 @@
-$(var robot_name):
+/**:
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx200_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx200_controllers.yaml
@@ -1,4 +1,4 @@
-locobot:
+$(var robot_name):
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx200_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx200_controllers.yaml
@@ -1,4 +1,4 @@
-$(var robot_name):
+/**:
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx250s_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/create3_version/locobot_wx250s_controllers.yaml
@@ -1,4 +1,4 @@
-locobot:
+/**:
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_base_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_base_controllers.yaml
@@ -1,4 +1,4 @@
-locobot:
+$(var robot_name):
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_base_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_base_controllers.yaml
@@ -1,4 +1,4 @@
-$(var robot_name):
+/**:
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_px100_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_px100_controllers.yaml
@@ -1,4 +1,4 @@
-locobot:
+$(var robot_name):
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_px100_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_px100_controllers.yaml
@@ -1,4 +1,4 @@
-$(var robot_name):
+/**:
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx200_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx200_controllers.yaml
@@ -1,4 +1,4 @@
-locobot:
+$(var robot_name):
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx200_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx200_controllers.yaml
@@ -1,4 +1,4 @@
-$(var robot_name):
+/**:
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx250s_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx250s_controllers.yaml
@@ -1,4 +1,4 @@
-locobot:
+$(var robot_name):
   controller_manager:
     ros__parameters:
       update_rate: 1000

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx250s_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_sim/config/kobuki_version/locobot_wx250s_controllers.yaml
@@ -1,4 +1,4 @@
-$(var robot_name):
+/**:
   controller_manager:
     ros__parameters:
       update_rate: 1000


### PR DESCRIPTION
Set gazebo controller namespaces to wildcards, allowing configuration under any namespace.