### PR TITLE
[descriptions] [create3] Increased Kp and Kd values to stop "drifting" in Gazebo simulation

### DIFF
--- a/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/create3_version/bump_caster.urdf.xacro
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/create3_version/bump_caster.urdf.xacro
@@ -35,8 +35,8 @@
       <material>Gazebo/DarkGrey</material>
       <mu1>0.1</mu1>
       <mu2>0.1</mu2>
-      <kp>1000000.0</kp>
-      <kd>1.0</kd>
+      <kp>1e12</kp>
+      <kd>1e12</kd>
     </gazebo>
 
   </xacro:macro>

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/create3_version/caster.urdf.xacro
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/create3_version/caster.urdf.xacro
@@ -32,8 +32,8 @@
     <material>Gazebo/DarkGrey</material>
     <mu1>0.1</mu1>
     <mu2>0.1</mu2>
-    <kp>1000000.0</kp>
-    <kd>1.0</kd>
+    <kp>1e12</kp>
+    <kd>1e12</kd>
   </gazebo>
 
 </xacro:macro>

--- a/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/create3_version/wheel.urdf.xacro
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/create3_version/wheel.urdf.xacro
@@ -37,8 +37,8 @@
   <gazebo reference="${robot_name}/${wheel_link_name}">
     <mu1>1.0</mu1>
     <mu2>1.0</mu2>
-    <kp>1000000.0</kp>
-    <kd>100.0</kd>
+    <kp>1e12</kp>
+    <kd>1e12</kd>
     <minDepth>0.0001</minDepth>
     <maxVel>1.0</maxVel>
     <material>Gazebo/DarkGrey</material>


### PR DESCRIPTION
When simulating the robot with Gazebo, the robot would drift over time with no inputs. This PR increases the Kp and Kd values for the wheel, bump_caster, and caster. This change was inspired by other "fixes" throughout forums. The main idea is to increase stiffness (Kp) and then reduce any oscillations by increasing the dampening coefficient (Kd).

Before the change, after launching the sim, the robot would drift about 0.5-1m after ~5 min. After the change, there does not appear to be any movement after ~10 min. 