### PR TITLE
[moveit] Added right_finger to joints for the gripper controller

### DIFF
--- a/interbotix_ros_xslocobots/interbotix_xslocobot_moveit/config/controllers/mobile_wx250s_controllers.yaml
+++ b/interbotix_ros_xslocobots/interbotix_xslocobot_moveit/config/controllers/mobile_wx250s_controllers.yaml
@@ -20,3 +20,4 @@ locobot/gripper_controller:
   default: true
   joints:
     - left_finger
+    - right_finger


### PR DESCRIPTION
The current configuration results in errors when trying to move the gripper in the simulation. This update allows for the use of MoveIt in simulation for the gripper. Assuming this would also resolve a similar error on the physical robot; however, I have not verified that.